### PR TITLE
Fix Problem with MongoDB 3, using Mongoose 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "version": "1.0.5",
   "dependencies": {
     "express": "2.x.x",
-    "mongoose": "3.x.x",
+    "mongoose": "4.0.1",
     "redis": "0.x.x"
   },
   "main": "./lib/index.js",


### PR DESCRIPTION
Using mongodb 3, I get an error and a warning: 
Updating Mongoose fixed the issue I had and the warning.
> 
/usr/local/bin/sms-connector-lite/node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/base.js:246
        throw message;      
              ^
TypeError: Cannot read property 'length' of undefined
    at processResults (node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1581:31)
    at node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1619:20
    at node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1157:7
    at node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1890:9
    at Server.Base._callHandler (node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/base.js:448:41)
    at node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/server.js:481:18
    at MongoReply.parseBody (node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/responses/mongo_reply.js:68:5)
    at null.<anonymous> (node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/server.js:439:20)
    at emit (events.js:95:17)
    at null.<anonymous> (node_modules/express-sessions/node_modules/mongoose/node_modules/mongodb/lib/mongodb/connection/connection_pool.js:201:13)
